### PR TITLE
DRAFT: Parameterize SQL queries and add post-mod ANALYZE

### DIFF
--- a/(2) Vox Populi/Core Files/Overrides/CivilopediaScreen.lua
+++ b/(2) Vox Populi/Core Files/Overrides/CivilopediaScreen.lua
@@ -2774,7 +2774,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			thisPlayer = Players[Game.GetActivePlayer()];
 			if thisPlayer ~= nil then
 				leaderID = thisPlayer:GetLeaderType();
-				for leaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = " .. leaderID ) do
+				for leaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = ?", leaderID ) do
 					traitType = leaderTraits.TraitType;
 					break;
 				end
@@ -6385,7 +6385,7 @@ CivilopediaCategory[CategoryResources].SelectArticle = function( resourceID, sho
 		thisPlayer = Players[Game.GetActivePlayer()];
 		if thisPlayer ~= nil then
 			leaderID = thisPlayer:GetLeaderType();
-			for leaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = " .. leaderID ) do
+			for leaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = ?", leaderID ) do
 				traitType = leaderTraits.TraitType;
 				break;
 			end

--- a/(2) Vox Populi/Core Files/Overrides/PlotMouseoverInclude.lua
+++ b/(2) Vox Populi/Core Files/Overrides/PlotMouseoverInclude.lua
@@ -268,7 +268,7 @@ function GetResourceString(plot, bLongForm)
 
 	if pPlayer ~= nil then
 		iLeader = pPlayer:GetLeaderType();
-		for pLeaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = " .. iLeader ) do
+		for pLeaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = ?", iLeader ) do
 			eTrait = pLeaderTraits.TraitType;
 			break;
 		end

--- a/(3a) VP - EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua
+++ b/(3a) VP - EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua
@@ -467,7 +467,7 @@ local function UpdateTopPanelNow()
 	local traitType = "";
 	if g_activePlayer ~= nil then
 		leaderID = g_activePlayer:GetLeaderType();
-		for leaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = " .. leaderID ) do
+		for leaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = ?", leaderID ) do
 			traitType = leaderTraits.TraitType;
 			break;
 		end

--- a/CvGameCoreDLL_Expansion2/CustomMods.cpp
+++ b/CvGameCoreDLL_Expansion2/CustomMods.cpp
@@ -178,9 +178,11 @@ void CustomMods::prefetchCache() {
 	while (kPostDefines.Step()) {
 		Database::Results kLookup;
 		char szSQL[512];
-		sprintf_s(szSQL, "select ROWID from %s where Type = '%s' LIMIT 1", kPostDefines.GetText("Table"), kPostDefines.GetText("Type"));
+		// Table name must be concatenated (SQLite doesn't support parameterized identifiers)
+		sprintf_s(szSQL, "select ROWID from %s where Type = ? LIMIT 1", kPostDefines.GetText("Table"));
 
 		if (db->Execute(kLookup, szSQL)) {
+			kLookup.Bind(1, kPostDefines.GetText("Type"));
 			if (kLookup.Step()) {
 				kInsert.Bind(1, kPostDefines.GetText("Name"));
 				kInsert.Bind(2, kLookup.GetInt(0));

--- a/CvGameCoreDLL_Expansion2/CvDllDatabaseUtility.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllDatabaseUtility.cpp
@@ -175,6 +175,11 @@ bool CvDllDatabaseUtility::CacheGameDatabaseData()
 	//Clear out database cache and tune for runtime use.
 	DB.ClearCountCache();
 
+	// Refresh query planner statistics for indexes added by the mod.
+	// The engine runs ANALYZE before mods are loaded, so post-mod
+	// indexes (60+ from AddTableIndexes.sql) lack statistics.
+	DB.Analyze();
+
 	//Log Database Memory statistics
 	LogMsg(DB.CalculateMemoryStats());
 
@@ -223,17 +228,15 @@ bool CvDllDatabaseUtility::PerformDatabasePostProcessing()
 		const char* szTableName = kPostDefines.GetText("Table");
 		char szSQL[512];
 
-		sprintf_s(szSQL, "select ROWID from %s where Type = '%s' LIMIT 1", szTableName, szKeyName);
+		// Table name must be concatenated (SQLite doesn't support parameterized identifiers)
+		sprintf_s(szSQL, "select ROWID from %s where Type = ? LIMIT 1", szTableName);
 
 		Database::Results kLookup;
-
-		//Compile the command.
 		if(db->Execute(kLookup, szSQL))
 		{
-			//Run the command.
+			kLookup.Bind(1, szKeyName);
 			if(kLookup.Step())
 			{
-				//Perform insertion
 				kInsert.Bind(1, szName);
 				kInsert.Bind(2, kLookup.GetInt(0));
 				kInsert.Step();
@@ -485,19 +488,27 @@ void CvDllDatabaseUtility::DatabaseRemapper()
 								}
 								vTableIDs.push_back(kQuery.GetInt(0));
 							}
+							// Prepare UPDATE once per table, bind+execute for each row
+							char szUpdate[512];
+							sprintf_s(szUpdate, "UPDATE %s SET ID = ? WHERE ID = ?", szTableName);
+							Database::Results kUpdate;
 							bool bFirst = true;
-							for (uint ui = 0; ui < vTableIDs.size(); ui++)
+							if (DB.Execute(kUpdate, szUpdate))
 							{
-								if (vTableIDs[ui] != static_cast<int>(ui))
+								for (uint ui = 0; ui < vTableIDs.size(); ui++)
 								{
-									if (bFirst)
+									if (vTableIDs[ui] != static_cast<int>(ui))
 									{
-										LogMsg("Table %s: Remapping %u incorrect IDs, starting with %d -> %u. ", szTableName, vTableIDs.size() - ui, vTableIDs[ui], ui);
-										bFirst = false;
+										if (bFirst)
+										{
+											LogMsg("Table %s: Remapping %u incorrect IDs, starting with %d -> %u. ", szTableName, vTableIDs.size() - ui, vTableIDs[ui], ui);
+											bFirst = false;
+										}
+										kUpdate.Bind(1, (int)ui);
+										kUpdate.Bind(2, vTableIDs[ui]);
+										kUpdate.Execute();
+										kUpdate.Reset();
 									}
-									char szUpdate[512];
-									sprintf_s(szUpdate, "UPDATE %s SET ID = %d WHERE ID = %d;", szTableName, (int)ui, vTableIDs[ui]);
-									DB.Execute(szUpdate);
 								}
 							}
 						}

--- a/CvGameCoreDLL_Expansion2/CvInfos.cpp
+++ b/CvGameCoreDLL_Expansion2/CvInfos.cpp
@@ -4530,11 +4530,9 @@ bool CvHandicapInfo::CacheResults(Database::Results& kResults, CvDatabaseUtility
 		kUtility.InitializeArray(m_piGoodies, m_iNumGoodies, 0);
 
 		Database::Results kArrayResults;
-		char szSQL[512];
-		sprintf_s(szSQL, "select GoodyHuts.ID from HandicapInfo_Goodies inner join GoodyHuts on GoodyType = GoodyHuts.Type where HandicapType = '%s';", szHandicapType);
-
-		if (DB.Execute(kArrayResults, szSQL))
+		if (DB.Execute(kArrayResults, "select GoodyHuts.ID from HandicapInfo_Goodies inner join GoodyHuts on GoodyType = GoodyHuts.Type where HandicapType = ?"))
 		{
+			kArrayResults.Bind(1, szHandicapType);
 			int i = 0;
 			while (kArrayResults.Step())
 			{
@@ -4930,21 +4928,22 @@ bool CvGameSpeedInfo::CacheResults(Database::Results& kResults, CvDatabaseUtilit
 		const char* szGameSpeedInfoType = GetType();
 
 		//Calculate number of turn increments
-		char szCountSQL[256];
-		sprintf_s(szCountSQL, "select count(*) from GameSpeed_Turns where GameSpeedType = '%s'", szGameSpeedInfoType);
-		Database::SingleResult kCount;
-		if(DB.Execute(kCount, szCountSQL))
+		Database::Results kCount;
+		if(DB.Execute(kCount, "select count(*) from GameSpeed_Turns where GameSpeedType = ?"))
 		{
-			m_iNumTurnIncrements = kCount.GetInt(0);
+			kCount.Bind(1, szGameSpeedInfoType);
+			if(kCount.Step())
+			{
+				m_iNumTurnIncrements = kCount.GetInt(0);
+			}
 		}
 
 		//Update turn increments
 		allocateGameTurnInfos(getNumTurnIncrements());
-		char szSQL[256];
-		sprintf_s(szSQL, "select * from GameSpeed_Turns where GameSpeedType = '%s'", szGameSpeedInfoType);
 		Database::Results kArrayResults;
-		if(DB.Execute(kArrayResults, szSQL))
+		if(DB.Execute(kArrayResults, "select * from GameSpeed_Turns where GameSpeedType = ?"))
 		{
+			kArrayResults.Bind(1, szGameSpeedInfoType);
 			int i = 0;
 			while(kArrayResults.Step())
 			{
@@ -5372,13 +5371,10 @@ bool CvBuildInfo::CacheResults(Database::Results& kResults, CvDatabaseUtility& k
 		kUtility.InitializeArray(m_paiFeatureObsoleteTech, "Features");
 		kUtility.InitializeArray(m_pabFeatureRemoveOnly, "Features");
 
-		char szQuery[512];
-		const char* szFeatureQuery = "select * from BuildFeatures where BuildType = '%s'";
-		sprintf_s(szQuery, 512, szFeatureQuery, GetType());
-
 		Database::Results kArrayResults;
-		if(DB.Execute(kArrayResults, szQuery))
+		if(DB.Execute(kArrayResults, "select * from BuildFeatures where BuildType = ?"))
 		{
+			kArrayResults.Bind(1, GetType());
 			while(kArrayResults.Step())
 			{
 				const char* szFeatureType			= kArrayResults.GetText("FeatureType");
@@ -6572,11 +6568,9 @@ bool CvResourceInfo::CacheResults(Database::Results& kResults, CvDatabaseUtility
 		m_piResourceQuantityTypes[0] = 1;
 
 		Database::Results kArrayResults;
-		char szQuery[512];
-		sprintf_s(szQuery, "select Quantity from Resource_QuantityTypes where ResourceType = '%s';", szResourceType);
-
-		if(DB.Execute(kArrayResults, szQuery))
+		if(DB.Execute(kArrayResults, "select Quantity from Resource_QuantityTypes where ResourceType = ?"))
 		{
+			kArrayResults.Bind(1, szResourceType);
 			int i = 0;
 			while(kArrayResults.Step())
 			{

--- a/CvGameCoreDLL_Expansion2/CvProjectClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvProjectClasses.cpp
@@ -137,10 +137,9 @@ bool CvProjectEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility
 		kUtility.InitializeArray(m_piVictoryMinThreshold, iNumVictories);
 
 		Database::Results kDBResults;
-		char szQuery[512] = {0};
-		sprintf_s(szQuery, "select VictoryType, Threshold, MinThreshold from Project_VictoryThresholds where ProjectType = '%s';", szProjectType);
-		if(DB.Execute(kDBResults, szQuery))
+		if(DB.Execute(kDBResults, "select VictoryType, Threshold, MinThreshold from Project_VictoryThresholds where ProjectType = ?"))
 		{
+			kDBResults.Bind(1, szProjectType);
 			while(kDBResults.Step())
 			{
 				const char* szVictoryType = kDBResults.GetText("VictoryType");

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
@@ -3583,10 +3583,10 @@ bool CvPromotionEntry::IsUnitNaming(int i) const
 void CvPromotionEntry::GetUnitName(UnitTypes eUnit, CvString& sUnitName) const
 {
 	Database::Results kDBResults;
-	char szQuery[512] = {0};
-	sprintf_s(szQuery, "select Name from UnitPromotions_UnitName n, UnitPromotions p, Units u where n.PromotionType = p.Type and n.UnitType = u.Type and p.ID = %i and u.ID = %i;", GetID(), eUnit);
-	if(DB.Execute(kDBResults, szQuery))
+	if(DB.Execute(kDBResults, "select Name from UnitPromotions_UnitName n, UnitPromotions p, Units u where n.PromotionType = p.Type and n.UnitType = u.Type and p.ID = ? and u.ID = ?"))
 	{
+		kDBResults.Bind(1, GetID());
+		kDBResults.Bind(2, (int)eUnit);
 		while(kDBResults.Step())
 		{
 			sUnitName = kDBResults.GetText("Name");

--- a/UI_bc1/TopPanel/TopPanel.lua
+++ b/UI_bc1/TopPanel/TopPanel.lua
@@ -386,7 +386,7 @@ local function UpdateTopPanelNow()
 	local traitType = "";
 	if g_activePlayer ~= nil then
 		leaderID = g_activePlayer:GetLeaderType();
-		for leaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = " .. leaderID ) do
+		for leaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = ?", leaderID ) do
 			traitType = leaderTraits.TraitType;
 			break;
 		end


### PR DESCRIPTION
## Summary

Replace `sprintf_s` / string-concatenation SQL value interpolation with parameter binding (`?` + `Bind`) across all C++ and Lua code, and add a post-mod `ANALYZE` call to refresh query-planner statistics.

## Background

The game engine embeds **SQLite 3.7.17** (2013-05-20) statically linked in `CvGameDatabaseWin32.dll`.

The engine *does* expose proper parameterized query support:
- **C++**: `Database::Results` with `Bind(1, value)` / `Execute()` / `Reset()`
- **Lua**: `DB.Query("SELECT ... WHERE x = ?", value)`

Most mod code already uses binding correctly; this PR catches the remaining cases that used `sprintf_s` or Lua concatenation to build SQL strings.

## Changes

### C++ — 6 files, 11 queries

| File | Query | Change |
|------|-------|--------|
| `CvInfos.cpp` | HandicapInfo_Goodies | `%s` → `?` + `Bind` |
| `CvInfos.cpp` | GameSpeed_Turns count | `%s` → `?` + `Bind` (also SingleResult → Results — see note below) |
| `CvInfos.cpp` | GameSpeed_Turns select | `%s` → `?` + `Bind` |
| `CvInfos.cpp` | Resource_QuantityTypes | `%s` → `?` + `Bind` |
| `CvInfos.cpp` | BuildFeatures | `%s` → `?` + `Bind` |
| `CvProjectClasses.cpp` | Project_VictoryThresholds | `%s` → `?` + `Bind` |
| `CvPromotionClasses.cpp` | UnitPromotions_UnitName | `%s` → `?` + `Bind` |
| `CvDllDatabaseUtility.cpp` | PostDefines ROWID | `%s` → `?` + `Bind` |
| `CvDllDatabaseUtility.cpp` | DatabaseRemapper UPDATE | Converted to prepare-once / bind-per-row / reset pattern |
| `CustomMods.cpp` | CustomModPostDefines ROWID | `%s` → `?` + `Bind` |

### Lua — 4 files, 5 queries

| File | Query | Change |
|------|-------|--------|
| `CivilopediaScreen.lua` | Leader_Traits JOIN (×2) | String concat → `DB.Query("...?", value)` |
| `PlotMouseoverInclude.lua` | Leader_Traits JOIN | String concat → `DB.Query("...?", value)` |
| `TopPanel.lua` (×2 copies) | Leader_Traits JOIN | String concat → `DB.Query("...?", value)` |

### ANALYZE

Added `DB.Analyze()` in `CvDllDatabaseUtility::CacheGameDatabaseData()` after `ClearCountCache()`. This runs `ANALYZE` on the game database so SQLite's query planner has up-to-date statistics for the 60+ indexes added by mod SQL files. Without this, the planner uses default row estimates and may choose sub-optimal plans.

## Technical note: SingleResult → Results

`SingleResult()` internally calls `SetCommand()` which auto-steps the statement (confirmed via DLL disassembly at RVA 0x7BD0). This means the query has already executed *before* `Bind()` is called, making parameterization impossible with `SingleResult`. The GameSpeed_Turns count query was changed to use `Results` with explicit `SelectAt(Bind, Step)` to allow proper binding.

## Not changed

- **`PRAGMA table_info(tableName)`** in `VPUI_core.lua` — table names cannot be parameterized (expected SQL limitation)
- **Remaining `%s` in C++** — all are table/column identifiers, not values (cannot be parameterized)
- **`SelectWhere()` calls** — the engine builds WHERE clauses via internal `sprintf`; no bind path is available through the public API
- **`DB.Query` → `DB.CreateQuery` migration** for CivilopediaScreen's 51 calls — performance improvement only, deferred to a separate PR

## Build constraints

- C++03 / TR1 / VS2008 SP1 (v90 toolset) — all changes are compatible
- No new dependencies or APIs used